### PR TITLE
groups rinf updates for flutter and cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
       flutter:
         patterns:
           - "*"
+        exclude-patterns:
+          - 'rinf*'
+      rinf:
+        patterns:
+          - 'rinf*'
   - package-ecosystem: cargo
     directory: /
     schedule:
@@ -32,3 +37,8 @@ updates:
       cargo:
         patterns:
           - "*"
+        exclude-patterns:
+          - 'rinf*'
+      rinf:
+        patterns:
+          - 'rinf*'


### PR DESCRIPTION
should make dependabot use 1 PR to update rinf